### PR TITLE
stop calling old method

### DIFF
--- a/lib/uv_util2/big_query_log.rb
+++ b/lib/uv_util2/big_query_log.rb
@@ -60,7 +60,7 @@ module UvUtil2
       dataset = get_dataset
 
       # テーブルの取得または作成
-      bq_table = create_hour_table(dataset, now: now, block: block)
+      bq_table = create_hour_min_table(dataset, now: now, block: block)
 
       # アップロードするCSVファイルを一時ファイルとして作成する
       Tempfile.open(['bq_', '.csv']) do |file|


### PR DESCRIPTION
テーブルの分単位の分割のためにメソッド名を変えたときの、修正漏れに対応しました。